### PR TITLE
Perf

### DIFF
--- a/src/styled.js
+++ b/src/styled.js
@@ -35,8 +35,13 @@ const styled = (Comp, config = {}) => (style = {}) => {
     const styleProps = multi ? style : { style }
     const styleKeys = Object.keys(styleProps)
 
+    // fixed styles
+    const fixedStyleProps = multi ? fixedStyle : { style: fixedStyle }
+
     for (let i = 0; i < styleKeys.length; i += 1) {
       const prop = styleKeys[i]
+      const fixedPropValue = fixedStyleProps[prop] || {}
+
       styles[prop] = {
         ...styles[prop],
         ...flatten([
@@ -44,16 +49,8 @@ const styled = (Comp, config = {}) => (style = {}) => {
           typeof styleProps[prop] === 'function' ? styleProps[prop](props) : styleProps[prop],
           props[prop],
         ]),
+        ...fixedPropValue
       }
-    }
-
-    // fixed styles
-    const fixedStyleProps = multi ? fixedStyle : { style: fixedStyle }
-    const fixedStyleKeys = Object.keys(fixedStyleProps)
-
-    for (let i = 0; i < fixedStyleKeys.length; i += 1) {
-      const prop = fixedStyleKeys[i]
-      styles[prop] = { ...styles[prop], ...fixedStyleProps[prop] }
     }
 
     const parentProps = {
@@ -68,13 +65,13 @@ const styled = (Comp, config = {}) => (style = {}) => {
       { ref, ...parentProps },
       child
         ? React.createElement(
-            child,
-            {
-              ref: childRef,
-              ...(typeof childProps === 'function' ? childProps(parentProps) : childProps),
-            },
-            children
-          )
+          child,
+          {
+            ref: childRef,
+            ...(typeof childProps === 'function' ? childProps(parentProps) : childProps),
+          },
+          children
+        )
         : children
     )
   })


### PR DESCRIPTION
Slightly improves perf by:
 * skipping an unnecessary loop
 * skipping an unnecessary object expansion

Measurements using https://github.com/andrejborstnik/benchmark. Big variance in results, but after is consistently faster, as expected.

Before:
<img width="794" alt="Screenshot 2020-06-04 at 01 25 27" src="https://user-images.githubusercontent.com/5684380/83699432-48d1a400-a604-11ea-87fe-077b5c0ee13f.png">

After:
<img width="789" alt="Screenshot 2020-06-04 at 01 43 07" src="https://user-images.githubusercontent.com/5684380/83699662-e9c05f00-a604-11ea-84b5-8e0f9772bed2.png">

