### PR TITLE
feat: support react-native-reanimated styles

### DIFF
--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,0 +1,1 @@
+require('react-native-reanimated').setUpTests();

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@babel/core": "^7.24.3",
     "@emotion/native": "^11.11.0",
     "@emotion/react": "^11.11.4",
+    "@testing-library/react-native": "^12.4.5",
     "babel-jest": "^29.7.0",
     "benchmark": "2.1.4",
     "emotion": "9.2.6",
@@ -25,6 +26,7 @@
     "microtime": "^3.1.1",
     "react": "18.2.0",
     "react-native": "^0.73.6",
+    "react-native-reanimated": "^3.8.1",
     "react-test-renderer": "18.2.0",
     "rollup": "^4.13.2",
     "styled-components": "6.1.8"
@@ -45,7 +47,10 @@
     "verbose": true,
     "preset": "react-native",
     "transformIgnorePatterns": [
-      "/node_modules/(?!(@react-native|react-native)/).*/"
+      "/node_modules/(?!(@react-native|react-native|react-native-reanimated)/).*/"
+    ],
+    "setupFilesAfterEnv": [
+      "./jest-setup.js"
     ]
   },
   "files": [

--- a/src/styled.js
+++ b/src/styled.js
@@ -17,12 +17,25 @@ const styled = (Comp, config = {}) => (componentStyle = {}) => {
     let { attrs } = opts
     attrs = attrs ? attrs(props) : {}
 
-    const style = {
+    let style = {
       ...factoryStyle,
       ...attrs.style,
       ...(typeof componentStyle === 'function' ? componentStyle(props) : componentStyle),
-      ...props.style,
-      ...fixedStyle,
+    }
+    
+    if (props.style) {
+      // assuming this is react-native-reanimated >v2 style comming from useAnimatedStyle
+      if (props.style.hasOwnProperty('viewDescriptors')) {
+        style = [style, props.style, fixedStyle]
+      } else if (Array.isArray(props.style) && props.style.some(style => style.hasOwnProperty('viewDescriptors'))) {
+        style = [style, ...props.style, fixedStyle]
+      } else {
+        style = {
+          ...style,
+          ...props.style,
+          ...fixedStyle
+        }
+      }
     }
 
     const parentProps = {

--- a/test/reanimated.test.js
+++ b/test/reanimated.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import Animated, {useSharedValue, useAnimatedStyle} from 'react-native-reanimated'
+import { render } from '@testing-library/react-native';
+
+import s from '../src'
+
+const AnimatedComponent = () => {
+  const animatedValue = useSharedValue(0.5)
+  const Foo = s(Animated.View)({ flex: 1, opacity: 0 })
+  const animatedStyle = useAnimatedStyle(() => ({opacity: animatedValue.value}), [animatedValue])
+  return <Foo testID="foo" style={animatedStyle} />
+}
+
+it('works with reanimated styles', () => {
+  const { getByTestId } = render(<AnimatedComponent />);
+  const element = getByTestId('foo');
+  expect(element.props.style).toEqual({opacity: 0.5})
+  expect(element).toHaveAnimatedStyle({opacity: 0.5})
+})

--- a/test/reanimated.test.js
+++ b/test/reanimated.test.js
@@ -5,16 +5,31 @@ import { render } from '@testing-library/react-native';
 
 import s from '../src'
 
-const AnimatedComponent = () => {
-  const animatedValue = useSharedValue(0.5)
-  const Foo = s(Animated.View)({ flex: 1, opacity: 0 })
-  const animatedStyle = useAnimatedStyle(() => ({opacity: animatedValue.value}), [animatedValue])
-  return <Foo testID="foo" style={animatedStyle} />
-}
 
 it('works with reanimated styles', () => {
+  const AnimatedComponent = () => {
+    const animatedValue = useSharedValue(0.5)
+    const Foo = s(Animated.View)({ flex: 1, opacity: 0 })
+    const animatedStyle = useAnimatedStyle(() => ({opacity: animatedValue.value}), [animatedValue])
+    return <Foo testID="foo" style={animatedStyle} />
+  }
+  
   const { getByTestId } = render(<AnimatedComponent />);
   const element = getByTestId('foo');
-  expect(element.props.style).toEqual({opacity: 0.5})
+  expect(element.props.style).toEqual({opacity: 0.5, flex: 1})
+  expect(element).toHaveAnimatedStyle({opacity: 0.5})
+})
+
+it('works with reanimated styles when use array', () => {
+  const AnimatedComponent = () => {
+    const animatedValue = useSharedValue(0.5)
+    const Foo = s(Animated.View)({ flex: 1, opacity: 0 })
+    const animatedStyle = useAnimatedStyle(() => ({opacity: animatedValue.value}), [animatedValue])
+    return <Foo testID="foo" style={[animatedStyle, {width: 50}]} />
+  }
+  
+  const { getByTestId } = render(<AnimatedComponent />);
+  const element = getByTestId('foo');
+  expect(element.props.style).toEqual({opacity: 0.5, flex: 1, width: 50})
   expect(element).toHaveAnimatedStyle({opacity: 0.5})
 })


### PR DESCRIPTION
Depends on https://github.com/ExodusMovement/shakl/pull/12
https://app.asana.com/0/1202332025965022/1206950508328923/f

Issue: 
when create component using shakl with pre-defined styles and then pass animated styles to it, `react-native-reanimated` ignores pre-defined styles, it works only with animated once. 
Solution:
Split our animated and pre-defined styles in array: `[style, animatedStyle]`.

In theory this can be probably solved on `react-native-reanimated` lib level, somewhere here https://github.com/software-mansion/react-native-reanimated/blob/e88fb10d902ab73c3de8d916bc2c7f9a9d3069ad/src/createAnimatedComponent.js#L252-L262, but right now they explicitly recommend to:
> Only define the dynamic part of your styles with useAnimatedStyle and keep the static ones separately using StyleSheet API or (if you really have to) with inline styles. That way you avoid lots of unnecessary style recalculations. Static and dynamic styles can be easily merged using the [] syntax: