### PR TITLE
fix: handle undefined style

### DIFF
--- a/src/styled.js
+++ b/src/styled.js
@@ -23,16 +23,22 @@ const styled = (Comp, config = {}) => (componentStyle = {}) => {
       ...(typeof componentStyle === 'function' ? componentStyle(props) : componentStyle),
     }
     
-    if (props.style) {
+    let styleFromProps = props.style
+    
+    if (Array.isArray(styleFromProps)) {
+      styleFromProps = styleFromProps.filter(style => !!style)
+    }
+    
+    if (styleFromProps) {
       // assuming this is react-native-reanimated >v2 style comming from useAnimatedStyle
-      if (props.style.hasOwnProperty('viewDescriptors')) {
-        style = [style, props.style, fixedStyle]
-      } else if (Array.isArray(props.style) && props.style.some(style => style.hasOwnProperty('viewDescriptors'))) {
-        style = [style, ...props.style, fixedStyle]
+      if (styleFromProps.hasOwnProperty('viewDescriptors')) {
+        style = [style, styleFromProps, fixedStyle]
+      } else if (Array.isArray(styleFromProps) && styleFromProps.some(style => style.hasOwnProperty('viewDescriptors'))) {
+        style = [style, ...styleFromProps, fixedStyle]
       } else {
         style = {
           ...style,
-          ...props.style,
+          ...styleFromProps,
           ...fixedStyle
         }
       }

--- a/test/reanimated.test.js
+++ b/test/reanimated.test.js
@@ -33,3 +33,16 @@ it('works with reanimated styles when use array', () => {
   expect(element.props.style).toEqual({opacity: 0.5, flex: 1, width: 50})
   expect(element).toHaveAnimatedStyle({opacity: 0.5})
 })
+it('works with reanimated styles when use array and some style is undefined', () => {
+  const AnimatedComponent = () => {
+    const animatedValue = useSharedValue(0.5)
+    const Foo = s(Animated.View)({ flex: 1, opacity: 0 })
+    const animatedStyle = useAnimatedStyle(() => ({opacity: animatedValue.value}), [animatedValue])
+    return <Foo testID="foo" style={[undefined, null, animatedStyle, {width: 50}]} />
+  }
+  
+  const { getByTestId } = render(<AnimatedComponent />);
+  const element = getByTestId('foo');
+  expect(element.props.style).toEqual({opacity: 0.5, flex: 1, width: 50})
+  expect(element).toHaveAnimatedStyle({opacity: 0.5})
+})


### PR DESCRIPTION
some style maybe undefined when we define it like that in component `style={[animatedStyle, otherStyle, someUndefinedStyleFromProps]}`. in this case need to filter out it