### PR TITLE
fix: RN Stylesheet support

### DIFF
--- a/src/styled.js
+++ b/src/styled.js
@@ -30,10 +30,10 @@ const styled = (Comp, config = Object.create(null)) => (componentStyle = Object.
     }
     
     if (styleFromProps) {
-      // assuming this is react-native-reanimated >v2 style comming from useAnimatedStyle
-      if (styleFromProps.hasOwnProperty('viewDescriptors')) {
+      // assuming this is react-native-reanimated >v2 style comming from useAnimatedStyle or React-Native StyleSheet style
+      if (typeof styleFromProps === 'number' || styleFromProps.hasOwnProperty('viewDescriptors')) {
         style = [style, styleFromProps, fixedStyle]
-      } else if (Array.isArray(styleFromProps) && styleFromProps.some(style => style.hasOwnProperty('viewDescriptors'))) {
+      } else if (Array.isArray(styleFromProps)) {
         style = [style, ...styleFromProps, fixedStyle]
       } else {
         style = {

--- a/test/stylesheet.test.js
+++ b/test/stylesheet.test.js
@@ -1,0 +1,60 @@
+import React from 'react'
+
+import { render } from '@testing-library/react-native'
+
+import s from '../src'
+import {
+  View,
+  StyleSheet
+} from 'react-native'
+
+it('works with stylesheet styles', () => {
+  const stylesheetStyle = StyleSheet.create({
+    foo: {
+      marginBottom: 10
+    }
+  })
+  const StyledComponent = () => {
+    const Foo = s(View)({
+      flex: 1,
+      opacity: 0
+    })
+    return <Foo
+      testID="foo"
+      style={stylesheetStyle.foo}
+    />
+  }
+  
+  const { getByTestId } = render(<StyledComponent />)
+  const element = getByTestId('foo')
+  expect(element.props.style).toEqual({
+    marginBottom: 10,
+    flex: 1,
+    opacity: 0
+  })
+})
+
+it('works with stylesheet styles when use array', () => {
+  const stylesheetStyle = StyleSheet.create({
+    foo: {
+      marginBottom: 10
+    }
+  })
+  const StyledComponent = () => {
+    const Foo = s(View)({
+      flex: 1,
+      opacity: 0
+    })
+    return <Foo
+      testID="foo"
+      style={[stylesheetStyle.foo, { width: 10 }]}
+    />
+  }
+  
+  const { getByTestId } = render(<StyledComponent />)
+  const element = getByTestId('foo')
+  expect(element.props.style).toEqual([{
+    'flex': 1,
+    'opacity': 0
+  }, { 'marginBottom': 10 }, { 'width': 10 }, {}])
+})


### PR DESCRIPTION
StyleSheet.create creates style that is represented as number in react-native. 
If style defined as 
```
const styles= StyleSheet.create({foo: {marginBottom: 10}})

<Component style={[{width:100}, styles.foo]} />
``
it will fail with error
`Failed to set an indexed property [0] on 'CSSStyleDeclaration': Indexed property setter is not supported.`

This PR fixes it