### PR TITLE
fix: type support for props supplied in `.attrs()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "microtime": "^3.1.1",
     "react": "18.2.0",
     "react-native": "^0.73.6",
+    "react-native-linear-gradient": "^2.8.3",
     "react-native-reanimated": "^3.8.1",
     "react-test-renderer": "18.2.0",
     "rollup": "^4.13.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ const styled = <P extends object, S extends object = object, A extends Partial<P
   // Extend the Styled component with custom methods
   const StyledComponent = Object.assign(Styled, {
     extend: <SP2 extends object>(more: ComponentStyle<P, SP & SP2, S>) => styled(StyledComponent, { name })(more),
-    attrs: <DP extends P>(attrs: Attrs<DP>) => styled(StyledComponent, { attrs })() as StyledComponent<WithOptional<P, keyof DP>, S>,
+    attrs: <A2 extends P>(attrs: Attrs<A2>) => styled(StyledComponent, { attrs })() as StyledComponent<WithOptional<P, keyof A2>, S>,
     withComponent: (comp: React.ComponentType<any>) =>
       styled(StyledComponent, { comp })(componentStyle) as StyledComponent<P & SP, S>,
     withChild: (child: React.ComponentType<any>, childProps: any) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import React from 'react';
 import type {StyleProp} from "react-native";
 
-export interface Config<P extends object> {
+export interface Config<P extends object, A extends object> {
   name?: string;
   props?: Partial<P>;
   style?: any;
   fixedStyle?: any;
-  attrs?: Attrs<P>;
+  attrs?: Attrs<A>;
   comp?: React.ComponentType<any>;
   child?: React.ComponentType<any>;
   childProps?: ((props: any) => any) | any;
@@ -33,9 +33,9 @@ export type StyledComponent<P extends object, S extends object> = React.ForwardR
   withChild: (child: React.ComponentType<any>, childProps?: any) => StyledComponent<P, S>;
 };
 
-const styled = <P extends object, S extends object = object, A extends P | undefined = undefined>(
+const styled = <P extends object, S extends object = object, A extends Partial<P> = {}>(
   Comp: React.ComponentType<P>,
-  config: Config<P> = {}
+  config: Config<P, A> = {}
 ) => <SP extends object>(componentStyle?: ComponentStyle<P, SP, S>): StyledComponent<WithOptional<P & SP, keyof A>, S> => {
   const {
     name,

--- a/test/index.type-test.tsx
+++ b/test/index.type-test.tsx
@@ -38,9 +38,11 @@ const extendedWithLinear = Object.assign(extendedStyled, {
     })
 })
 
-const StyledLinear = extendedWithLinear.LinearGradient({ }).attrs({
+const DefaultLinearGradient = extendedWithLinear.LinearGradient({ }).attrs({
     colors: ['red', 'white'],
 })
+
+const DangerLinearGradient = styled(LinearGradient)({}).attrs({ colors: ['orange', 'red']})
 
 const MyScreen = () => {
     const ref = useRef()
@@ -83,9 +85,10 @@ const MyScreen = () => {
       {/* @ts-expect-error -- missing "colors" */}
       <LinearGradient/>
       {/* doesn't require optional props */}
-      <StyledLinear />
+      <DefaultLinearGradient />
+      <DangerLinearGradient />
       {/* but they can be provided */}
-      <StyledLinear colors={['blue', 'green']} />
+      <DefaultLinearGradient colors={['blue', 'green']} />
     </>
   )
 }

--- a/test/index.type-test.tsx
+++ b/test/index.type-test.tsx
@@ -1,18 +1,19 @@
-import React, { Text } from 'react-native'
+import React, {Text, ViewStyle} from 'react-native'
 import styled from '../src/index'
 import extendedStyled from '../src/rn'
 import {useRef} from "react";
+import LinearGradient, { LinearGradientProps } from 'react-native-linear-gradient'
 
 const StyledText = styled(Text)(({ transparent }: { transparent?: boolean; color: string }) => ({ flex: 1, opacity: transparent ? 0.5 : 1 }))
+const StyledTextWithAttrs = StyledText.attrs({ color: 'black' })
+const StyledTextWithAttrsFromConfig = styled(StyledText, { attrs: { color: 'black' } })()
 const StyledScalableText = StyledText.extend(({ big }: { big?: boolean }) => ({ fontSize: big ? 20 : 10 }))
 const StyledTextWithObjectProps = styled(Text)({ flex: 1, opacity: 1 })
 const ExtendedStyledText = extendedStyled.Text(({ transparent }: { transparent?: boolean; }) => ({ flex: 1, opacity: transparent ? 0.5 : 1 }))
-
-const ExtenedStyledTextWithAttrs = extendedStyled.Text(({ transparent }: { transparent?: boolean; big?:boolean }) => ({ flex: 1, opacity: transparent ? 0.5 : 1 })).attrs(({big}: {big?: boolean}) => ({
+const ExtendedStyledTextWithStyle = extendedStyled(Text)((props: {specificColor: string}) => ({color: props.specificColor}))
+const ExtenedStyledTextWithAttrs = extendedStyled.Text(({ transparent }: { transparent?: boolean; big?:boolean }) => ({ flex: 1, opacity: transparent ? 0.5 : 1 })).attrs(({ big}) => ({
     ellipsizeMode: big ? 'middle' : 'head',
 }))
-const ExtendedStyledTextWithStyle = extendedStyled(Text)((props: {specificColor: string}) => ({color: props.specificColor}))
-
 
 const StyledView = extendedStyled.View({width: 100})
 const StyledViewWithDynamicProps = extendedStyled.View((props: {active: boolean}) => ({width: props.active ? 100 : 50}))
@@ -31,12 +32,24 @@ const StyledTouchable = extendedStyled.Touchable({width: 100})
 const StyledTouchableWithDynamicProps = extendedStyled.Image((props: {active: boolean}) => ({width: props.active ? 100 : 50}))
 const ViewWithText = extendedStyled.View({}).withChild(StyledText)
 
+const extendedWithLinear = Object.assign(extendedStyled, {
+    LinearGradient: styled<LinearGradientProps, ViewStyle>(LinearGradient, {
+        name: 'styled(LinearGradient)',
+    })
+})
+
+const StyledLinear = styled(LinearGradient)({}).attrs({
+    colors: ['red', 'white'],
+})
+
 const MyScreen = () => {
     const ref = useRef()
   return (
     <>
       <StyledText color="red" transparent>Hello Transparent World</StyledText>
       <StyledText ref={ref} color="red">Hello Transparent World with ref</StyledText>
+      <StyledTextWithAttrs>Color set through .attrs() and therefore not required</StyledTextWithAttrs>
+      <StyledTextWithAttrsFromConfig>Color is set through config.attrs and therefore not required</StyledTextWithAttrsFromConfig>
       {/* should also work without transparent prop */}
       <StyledText color="red">Hello World</StyledText>
       {/* @ts-expect-error -- should not work without required color prop */}
@@ -66,6 +79,10 @@ const MyScreen = () => {
       <StyledTouchableWithDynamicProps active>Touchable with dynamic style</StyledTouchableWithDynamicProps>
 
       <ViewWithText />
+      {/* doesn't require optional props */}
+      <StyledLinear />
+      {/* but they can be provided */}
+      <StyledLinear colors={['blue', 'green']} />
     </>
   )
 }

--- a/test/index.type-test.tsx
+++ b/test/index.type-test.tsx
@@ -38,7 +38,7 @@ const extendedWithLinear = Object.assign(extendedStyled, {
     })
 })
 
-const StyledLinear = styled(LinearGradient)({}).attrs({
+const StyledLinear = extendedWithLinear.LinearGradient({ }).attrs({
     colors: ['red', 'white'],
 })
 
@@ -79,6 +79,9 @@ const MyScreen = () => {
       <StyledTouchableWithDynamicProps active>Touchable with dynamic style</StyledTouchableWithDynamicProps>
 
       <ViewWithText />
+
+      {/* @ts-expect-error -- missing "colors" */}
+      <LinearGradient/>
       {/* doesn't require optional props */}
       <StyledLinear />
       {/* but they can be provided */}

--- a/test/index.type-test.tsx
+++ b/test/index.type-test.tsx
@@ -38,11 +38,10 @@ const extendedWithLinear = Object.assign(extendedStyled, {
     })
 })
 
-const DefaultLinearGradient = extendedWithLinear.LinearGradient({ }).attrs({
-    colors: ['red', 'white'],
+const DangerGradient = styled(LinearGradient)().attrs({ colors: ['orange', 'red']})
+const DefaultGradient = extendedWithLinear.LinearGradient({ }).attrs({
+    colors: ['blue', 'green'],
 })
-
-const DangerLinearGradient = styled(LinearGradient)({}).attrs({ colors: ['orange', 'red']})
 
 const MyScreen = () => {
     const ref = useRef()
@@ -85,10 +84,10 @@ const MyScreen = () => {
       {/* @ts-expect-error -- missing "colors" */}
       <LinearGradient/>
       {/* doesn't require optional props */}
-      <DefaultLinearGradient />
-      <DangerLinearGradient />
+      <DefaultGradient />
+      <DangerGradient />
       {/* but they can be provided */}
-      <DefaultLinearGradient colors={['blue', 'green']} />
+      <DefaultGradient colors={['blue', 'green']} />
     </>
   )
 }


### PR DESCRIPTION
This makes properties passed into `attrs()` optional on the resulting component.

E.g. a component `LinearGradient` that requires the `colors` prop, can be wrapped as follows:

```ts
const DefaultGradient = styled(LinearGradient, { attrs: { colors: ['red', 'blue'] })()
// or
const ErrorGradient = styled(LinearGradient)().attrs({ colors: ['red', 'orange'] })
```

They won't require consumers to pass the required `colors` prop