### PR TITLE
chore: make sure package is built before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "benchmark": "jest /benchmark",
     "postbenchmark": "open -a Chrome benchmark/chart/index.html",
     "prebuild": "rm -rf lib",
-    "build": "tsc"
+    "build": "tsc",
+    "prepublishOnly": "yarn build"
   },
   "files": [
     "lib"


### PR DESCRIPTION
So we don't accidentally publish stale files 