### PR TITLE
feat: add omitProps 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export interface Config<P extends object, A extends object> {
   comp?: React.ComponentType<any>
   child?: React.ComponentType<any>
   childProps?: ((props: any) => any) | any
-  omitProps?: string[]
+  omitProps?: Extract<keyof P, string>[]
   [key: string]: any
 }
 
@@ -53,7 +53,7 @@ const styled =
       props: factoryProps = Object.create(null),
       style: factoryStyle = Object.create(null),
       fixedStyle = Object.create(null),
-      omitProps = DEFAULT_OMIT_PROPS,
+      omitProps = DEFAULT_OMIT_PROPS as Extract<keyof P, string>[],
       ...opts
     } = config
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export interface Config<P extends object, A extends object> {
   comp?: React.ComponentType<any>
   child?: React.ComponentType<any>
   childProps?: ((props: any) => any) | any
+  omitProps?: string[]
   [key: string]: any
 }
 
@@ -26,6 +27,8 @@ type Attrs<A extends object> = ((props: Partial<A>) => Partial<A>) | Partial<A>
 type ComponentStyle<P extends object, SP extends object, S extends object> =
   | ((props: Partial<P> & SP) => S)
   | S
+
+const DEFAULT_OMIT_PROPS = ['theme']
 
 export type StyledComponent<P extends object, S extends object> = React.ForwardRefExoticComponent<
   React.PropsWithoutRef<P & StyledProps<S> & { children?: React.ReactNode }> &
@@ -50,6 +53,7 @@ const styled =
       props: factoryProps = Object.create(null),
       style: factoryStyle = Object.create(null),
       fixedStyle = Object.create(null),
+      omitProps = DEFAULT_OMIT_PROPS,
       ...opts
     } = config
 
@@ -95,6 +99,12 @@ const styled =
             }
           }
         }
+
+        omitProps.forEach((excludeProp) => {
+          if ((restProps as Record<string, any>)[excludeProp]) {
+            delete (restProps as Record<string, any>)[excludeProp]
+          }
+        })
 
         const parentProps = {
           ...factoryProps,

--- a/test/__snapshots__/props.test.js.snap
+++ b/test/__snapshots__/props.test.js.snap
@@ -10,3 +10,28 @@ exports[`accepts a style prop 1`] = `
   }
 />
 `;
+
+exports[`doesn't pass \`theme\` property by default 1`] = `
+<View
+  style={
+    {
+      "color": "#193bc3",
+    }
+  }
+/>
+`;
+
+exports[`passes \`theme\` property if \`omitProps\` specified without it 1`] = `
+<View
+  style={
+    {
+      "color": "#193bc3",
+    }
+  }
+  theme={
+    {
+      "fancyColor": "#193bc3",
+    }
+  }
+/>
+`;

--- a/test/props.test.js
+++ b/test/props.test.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { View } from 'react-native'
 import { create as r } from 'react-test-renderer'
 
 import s from '../src/rn'
@@ -8,6 +9,32 @@ it('accepts a style prop', () => {
   const foo = r(<Foo style={{ flex: 1 }} />).toJSON()
 
   expect(foo.props.style).toEqual({ margin: 10, flex: 1 })
+
+  expect(foo).toMatchSnapshot()
+})
+
+const theme = {
+  fancyColor: '#193bc3',
+}
+
+it("doesn't pass `theme` property by default", () => {
+  const Foo = s.View(({ theme }) => ({ color: theme.fancyColor }))
+  const foo = r(<Foo theme={theme} />).toJSON()
+
+  expect(foo.props.style).toEqual({
+    color: '#193bc3',
+  })
+
+  expect(foo).toMatchSnapshot()
+})
+
+it('passes `theme` property if `omitProps` specified without it', () => {
+  const Foo = s(View, { omitProps: [] })(({ theme }) => ({ color: theme.fancyColor }))
+  const foo = r(<Foo theme={theme} />).toJSON()
+
+  expect(foo.props.style).toEqual({
+    color: '#193bc3',
+  })
 
   expect(foo).toMatchSnapshot()
 })


### PR DESCRIPTION
Adds `omitProps` config with default to omit `theme` prop passing since its a common use case to wrap the component with `withTheme` for styles only needed in shakl's style callback but not inside actual component.

Closes: https://app.asana.com/0/1201379636186833/1209212141439843

