### PR TITLE
chore: specify engines and packageManager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "license": "MIT",
+  "engines": {
+    "node": ">=20.19.0"
+  },
+  "packageManager": "yarn@1.22.22",
   "name": "shakl",
   "description": "A utility to create styled components in React Native.",
   "version": "0.0.22",


### PR DESCRIPTION
## Summary
- Add `engines.node >= 20.19.0` (required by `eslint-visitor-keys@5.0.1`)
- Add `packageManager: yarn@1.22.22` to make the package manager explicit

## Test plan
- [x] `yarn install` succeeds
- [x] `yarn test` passes
- [x] `yarn lint` passes